### PR TITLE
Fix additional_fields columns always being NULL

### DIFF
--- a/python_sqlite_log_handler/__init__.py
+++ b/python_sqlite_log_handler/__init__.py
@@ -188,6 +188,10 @@ class SQLiteLogHandler(BufferingHandler):
         if extra_attrs:
             data["extra"] = json.dumps(extra_attrs)
 
+        # Populate additional_fields columns
+        for field_name, _ in self.additional_fields:
+            data[field_name] = extra_attrs.get(field_name)
+
         return data
 
     def flush(self) -> None:


### PR DESCRIPTION
- What's wrong: additional_fields columns are created in the schema but _extract_record_data never populates them. Values end up only in the JSON extra column.
- The fix: Always include additional_fields keys in the data dict (defaulting to None), so they're consistently present in the INSERT column list.
- The column list is built from the first record in a flush batch. If that first record lacks the extra field, the column is omitted from the INSERT entirely, meaning all records in that batch get NULL — even ones that had the value. Therefore,  get() is used to force all additional fields for every record.
- Example:

Setting up a logger like this:
```
logging.basicConfig(level=logging.DEBUG)
logger = logging.getLogger()
sqlite_extra_fields = [("user_id", "INTEGER")]
sqlite_handler = SQLiteLogHandler(
    db_path="logs.db",
    additional_fields=sqlite_extra_fields,
)
logger.addHandler(sqlite_handler)
```
and then logging with:
`logger.info("Message", extra={"user_id": int(user_id)})`

results in a column for user_id but all the values are always NULL.